### PR TITLE
Added missing journal class to div

### DIFF
--- a/app/views/hooks/inline_image_hook/_inline_images_paste.erb
+++ b/app/views/hooks/inline_image_hook/_inline_images_paste.erb
@@ -1,4 +1,4 @@
-<div class="attachments" style="margin-bottom: 16px;">
+<div class="journal attachments" style="margin-bottom: 16px;">
   <% journal.details.where(property: 'attachment').each do |a| %>
 
       <% attachment = Attachment.find_by_id a.prop_key %>


### PR DESCRIPTION
Added missing journal class to inline images, so that other plugins that expect journal entries to be classified as journal can manipulate the inline image
example: (https://github.com/markedagain/redmine_issue_detailed_tabs_time)
